### PR TITLE
Add fullscreen data loader class

### DIFF
--- a/LibraryAppProject/ElementsAndStructures/DataStructures.swift
+++ b/LibraryAppProject/ElementsAndStructures/DataStructures.swift
@@ -99,15 +99,19 @@ struct UpdLibraryData: Identifiable {
     var libLink: String?
 }
 
-// MARK: Data structures for mapping
+// MARK: Data structures for mapping info
 
 struct EventResponse: Codable {
     var events: [LibEvent]
 }
 
+struct FullscreenNotificationResponse: Codable {
+    var notification: FullscreenNotification
+}
+
 // MARK: Data structure for NotificationView
 
-struct FullscreenNotification {
+struct FullscreenNotification: Codable {
     var imageURL: String
     var header: String
     var mainText: String

--- a/LibraryAppProject/ReceivingData/DataGetFunc.swift
+++ b/LibraryAppProject/ReceivingData/DataGetFunc.swift
@@ -136,15 +136,15 @@ func getEventsByLibId(libId: Int) -> [LibEvent] {
 }
 
 
-func getFullscreenData() -> FullscreenNotification? {
-    let data = FullscreenNotification(
-        imageURL: "https://ucare.timepad.ru/301b3a31-3f8f-4024-af08-71cb9e1d087b/-/preview/1248x1248/-/format/jpeg/poster_event_3087406.jpg",
-        header: "Заголовок",
-        mainText: "Основной текст уведомления, который может занимать несколько строк.",
-        eventsId: 3
-    )
-    
+//func getFullscreenData() -> FullscreenNotification? {
+//    let data = FullscreenNotification(
+//        imageURL: "https://ucare.timepad.ru/301b3a31-3f8f-4024-af08-71cb9e1d087b/-/preview/1248x1248/-/format/jpeg/poster_event_3087406.jpg",
+//        header: "Заголовок",
+//        mainText: "Основной текст уведомления, который может занимать несколько строк.",
+//        eventsId: 3
+//    )
+//    
 //    let data: FullscreenNotification? = nil
-    
-    return data
-}
+//    
+//    return data
+//}

--- a/LibraryAppProject/ReceivingData/dataLoaderClasses.swift
+++ b/LibraryAppProject/ReceivingData/dataLoaderClasses.swift
@@ -1,8 +1,20 @@
 import Foundation
 
+// MARK: - Events List Loader Class
 
-class EventLoader: ObservableObject {
+class EventsListLoader: ObservableObject {
+    
+    // MARK: - Public Properties
+    
     @Published var libEvents: [LibEvent] = []
+    
+    // MARK: - Initialization
+    
+    init() {
+        loadEvents()
+    }
+    
+    // MARK: - Public Methods
 
     func loadEvents() {
         guard let url = URL(string: "https://testapi.com/events") else { return }
@@ -12,7 +24,6 @@ class EventLoader: ObservableObject {
             
             let decoder = JSONDecoder()
             do {
-                // Декодирование объекта с ключом `events`
                 let response = try decoder.decode(EventResponse.self, from: data)
                 DispatchQueue.main.async {
                     self.libEvents = response.events
@@ -23,3 +34,40 @@ class EventLoader: ObservableObject {
         }.resume()
     }
 }
+
+// MARK: - Fullscreen Loader Class
+
+class FullscreenLoader: ObservableObject {
+
+    // MARK: - Public Properties
+
+    @Published var fullscreenData: FullscreenNotification? = nil
+
+    // MARK: - Initialization
+
+    init() {
+        loadFullscreenData()
+    }
+
+    // MARK: - Private Methods
+
+    private func loadFullscreenData() {
+        guard let url = URL(string: "https://testapi.com/fullscreen") else { return }
+
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            guard let data = data else { return }
+
+            let decoder = JSONDecoder()
+            do {
+                let response = try decoder.decode(FullscreenNotificationResponse.self, from: data)
+                DispatchQueue.main.async {
+                    self.fullscreenData = response.notification
+                }
+            } catch {
+                print("Ошибка декодирования фуллскрина: \(error)")
+            }
+        }.resume()
+    }
+}
+
+

--- a/LibraryAppProject/TabPages/LibEventsView.swift
+++ b/LibraryAppProject/TabPages/LibEventsView.swift
@@ -84,7 +84,6 @@ struct LibEventsView: View {
                         .padding(.bottom, 5)
                 }
             }
-            
         }
     }
 }


### PR DESCRIPTION
- Add `loadFullscreenData` class to `dataLoaderClasses`
- Add marks to data loader classes
- Add `init()` method to `EventsListLoader`, that need for getting data of pages, when app start
- Remove `onAppear` modifier and add `onRecieve` in `ContentView`
- Add `pull-to-refresh` to `LibrariesView` and `LibEventsView`